### PR TITLE
[fix] prevent some iOS BottomSheetContainer.LayoutSubviews() and BottomSheet.NotifyDismissed() NullReferenceException by enforc…

### DIFF
--- a/src/BottomSheet.cs
+++ b/src/BottomSheet.cs
@@ -145,7 +145,7 @@ public partial class BottomSheet : ContentView
 
     internal void NotifyDismissed()
     {
-        this.Parent.RemoveLogicalChild(this);
+        this.Parent?.RemoveLogicalChild(this);
         Dismissed?.Invoke(this, _dismissOrigin);
     }
 

--- a/src/Platforms/iOS/BottomSheetContainer.cs
+++ b/src/Platforms/iOS/BottomSheetContainer.cs
@@ -36,10 +36,13 @@ internal class BottomSheetContainer : UIView
     public override void LayoutSubviews()
     {
         base.LayoutSubviews();
-        var h = CalculateTallestDetent(_sheet.Window.Height - BottomSheetManager.KeyboardHeight);
-        _view.Frame = new CGRect(0, 0, Bounds.Width, h);
-        _sheet.Arrange(_view.Frame.ToRectangle());
-        _sheet.Controller.Layout();
+        if (this._sheet != null && _sheet.Window != null)
+        {
+            var h = CalculateTallestDetent(_sheet.Window.Height - BottomSheetManager.KeyboardHeight);
+            _view.Frame = new CGRect(0, 0, Bounds.Width, h);
+            _sheet.Arrange(_view.Frame.ToRectangle());
+            _sheet.Controller.Layout();
+        }
     }
 }
 


### PR DESCRIPTION
On iOS I often encounter exceptions in BottomSheetContainer.LayoutSubviews() and BottomSheet.NotifyDismissed()

These occurs mainly in context where multiple sheets are displayed at once or when closing sheet with gestures.

I comment on [#94](https://github.com/the49ltd/The49.Maui.BottomSheet/issues/94) to explain that these behaviors are mainly tied to null checks on `Window`. I also observed that `Parent` may be null, thus this PR.

_n.b These exceptions can't be handle from our code as they occurs autonomously inside this library. (the callstack is like Program.cs -> The49.Maui.BottomSheet.NotifyDismissed_