### PR TITLE
[Android] Support showing Google Maps-like BottomSheet.

### DIFF
--- a/sample/AppShell.xaml
+++ b/sample/AppShell.xaml
@@ -4,8 +4,12 @@
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:local="clr-namespace:The49.Maui.BottomSheet.Sample"
-    Shell.FlyoutBehavior="Disabled"
-    Shell.NavBarIsVisible="False">
+    Shell.NavBarIsVisible="True"
+    Shell.TabBarIsVisible="True">
+
+    <!-- Note: We show the NavBar and TabBar to verify regular bottom sheets show
+    over (in front of) them, while "page" bottom sheets show under (behind) them.
+    -->
 
     <ShellContent
         Title="Home"
@@ -15,6 +19,5 @@
     <FlyoutItem>
         <ShellContent ContentTemplate="{DataTemplate local:ModalPage}" Route="ModalPage" />
     </FlyoutItem>
-
 
 </Shell>

--- a/sample/MainPage.xaml.cs
+++ b/sample/MainPage.xaml.cs
@@ -168,6 +168,20 @@ public partial class MainPage : ContentPage
             Command = new Command(OpenCustomizeBehavior),
         },
 #endif
+#if ANDROID
+        new DemoEntry
+        {
+            Title = "Modal Sheet (Inside Page)",
+            Description = "Shows behind the navigation bar, flyout, etc.",
+            Command = new Command(OpenModalSheet_WithinPage),
+        },
+        new DemoEntry
+        {
+            Title = "Non-Modal Sheet (Inside Page)",
+            Description = "Shows behind the navigation bar, flyout, etc.",
+            Command = new Command(OpenNonModalSheet_WithinPage),
+        },
+#endif
     };
 
     private void OpenSimpleSheet()
@@ -437,6 +451,42 @@ public partial class MainPage : ContentPage
             page.Controller.SheetPresentationController.PreferredCornerRadius = 2;
         };
         page.ShowAsync(Window);
+    }
+#endif
+
+#if ANDROID
+    void OpenModalSheet_WithinPage()
+    {
+        var page = new SimplePage();
+        page.Detents = new DetentsCollection()
+        {
+            new FullscreenDetent(),
+            new ContentDetent(),
+        };
+        page.HasBackdrop = true;
+        var b = new Button
+        {
+            Text = "Go to page"
+        };
+
+        var g = new TapGestureRecognizer
+        {
+            Command = new Command(() =>
+            {
+                page.DismissAsync(false);
+                Shell.Current.GoToAsync("//ModalPage");
+            }),
+        };
+
+        b.GestureRecognizers.Add(g);
+        page.SetExtraContent(b);
+        page.ShowAsync(this);
+    }
+
+    void OpenNonModalSheet_WithinPage()
+    {
+        var sheet = new ScrollSheet();
+        sheet.ShowAsync(this);
     }
 #endif
 

--- a/src/BottomSheet.cs
+++ b/src/BottomSheet.cs
@@ -107,6 +107,30 @@ public partial class BottomSheet : ContentView
         return completionSource.Task;
     }
 
+    /// <summary>
+    /// Shows the bottom sheet "within" the page.
+    /// The sheet will be obscured by flyout page and shows vertically above
+    /// navigation bar/tab bar.
+    /// </summary>
+    public Task ShowAsync(Page page, bool animated = true)
+    {
+        var completionSource = new TaskCompletionSource();
+        void OnShown(object? sender, EventArgs e)
+        {
+            Shown -= OnShown;
+            completionSource.SetResult();
+        }
+        Shown += OnShown;
+
+        if (SelectedDetent is null)
+        {
+            SelectedDetent = GetDefaultDetent();
+        }
+        page.AddLogicalChild(this);
+        BottomSheetManager.Show(page, this, animated);
+        return completionSource.Task;
+    }
+
     public Task DismissAsync(bool animated = true)
     {
         _dismissOrigin = DismissOrigin.Programmatic;

--- a/src/BottomSheetManager.cs
+++ b/src/BottomSheetManager.cs
@@ -8,11 +8,18 @@ internal partial class BottomSheetManager
         sheet.SizeChanged += OnSizeChanged;
     }
 
+    internal static void Show(Page page, BottomSheet sheet, bool animated)
+    {
+        PlatformShow(page, sheet, animated);
+        sheet.SizeChanged += OnSizeChanged;
+    }
+
     static void OnSizeChanged(object sender, EventArgs e)
     {
         PlatformLayout((BottomSheet)sender);
     }
 
     static partial void PlatformShow(Window window, BottomSheet sheet, bool animated);
+    static partial void PlatformShow(Page page, BottomSheet sheet, bool animated);
     static partial void PlatformLayout(BottomSheet sheet);
 }

--- a/src/Platforms/Android/BottomSheetManager.cs
+++ b/src/Platforms/Android/BottomSheetManager.cs
@@ -4,7 +4,16 @@ internal partial class BottomSheetManager
 {
     static partial void PlatformShow(Window window, BottomSheet sheet, bool animated)
     {
-        var controller = new BottomSheetController(window.Handler.MauiContext, sheet);
+        var controller = new BottomSheetController(window.Handler.MauiContext, sheet, showNextToAppBarLayout: false);
+        sheet.Controller = controller;
+        controller.Show(animated);
+    }
+
+    static partial void PlatformShow(Page page, BottomSheet sheet, bool animated)
+    {
+        // For pages, add the bottomsheet next to the AppBarLayout.
+        // This ensures that the bottomsheet shows "within" the page.
+        var controller = new BottomSheetController(page.Handler.MauiContext, sheet, showNextToAppBarLayout: true);
         sheet.Controller = controller;
         controller.Show(animated);
     }

--- a/src/Platforms/iOS/BottomSheetManager.cs
+++ b/src/Platforms/iOS/BottomSheetManager.cs
@@ -9,6 +9,10 @@ internal partial class BottomSheetManager
     private static nfloat _keyboardHeight;
     private static object _keyboardDidHideObserver;
 
+    // TODO: Implement this in iOS!
+    static partial void PlatformShow(Page page, BottomSheet sheet, bool animated)
+    {}
+
     static partial void PlatformShow(Window window, BottomSheet sheet, bool animated)
     {
         sheet.Parent = window;


### PR DESCRIPTION
Issue:
- Currently the BottomSheet implementation (on Android) always shows Z-order wise above other components like bottom navigation bar, tab bars, and flyouts.
- Google Maps shows a BottomSheet that is "within" the page - the sheet shows up vertically above (rather than in front of) the bottom navigation/tab bars.
- To implement such an experience, rather than adding the BottomSheet StayOnFrontView to the root ViewGroup, instead add it as a sibling of AppBarLayout.
- This ensures that the BottomSheet shows up behind the navigation bar/Tab bar on the bottom (BottomNavigationView) and the flyouts.

Changes:
1. BottomSheet, BottomSheetManager:
- Provide another overload of ShowAsync to accept a Page.

2. Android:
- Update EnsureStayOnFrontView to show as a sibling of AppBarLayout when showing "inside" a page.

3. sample:
- AppShell: Force showing the bottom tab bar, and the flyout menu option.
- MainPage: add test cases for modal and non-modal for the Google Maps style behavior.

This PR has no changes to any existing behavior or usage.

Google Maps style:
![GoogleMapsStyle](https://github.com/user-attachments/assets/9390ef33-6cf2-447d-b610-98e9cc6219a7)

(Regular sheets, unchanged behavior)
![RegularSheet](https://github.com/user-attachments/assets/cfc43472-4806-4e6d-96b8-9b9bee85e90e)
